### PR TITLE
Fix incorrect `None` on sequential pops & Avoid Endless loop on `set_capacity`

### DIFF
--- a/src/lfu/freq_list.rs
+++ b/src/lfu/freq_list.rs
@@ -182,11 +182,9 @@ impl<Key: Hash + Eq, T> FrequencyList<Key, T> {
             let item = head_node.pop();
             if head_node.elements.is_none() {
                 self.len -= 1;
-                self.head = head_node.prev;
-                if let Some(mut next) = head_node.next {
-                    let next_node = unsafe { next.as_mut() };
-                    next_node.next = head_node.next;
-                }
+                // Remove the now empty head
+                self.head = head_node.next;
+                head_node.prev = None;
             }
             return item;
         }

--- a/src/lfu/mod.rs
+++ b/src/lfu/mod.rs
@@ -540,6 +540,16 @@ mod pop {
         assert_eq!(None, cache.pop_lfu());
         assert_eq!(None, cache.pop_lfu_key_value());
     }
+
+    #[test]
+    fn set_capacity() {
+        let mut cache = LfuCache::unbounded();
+        for i in 0..100 {
+            cache.insert(i, i + 100);
+        }
+        cache.set_capacity(10);
+        assert_eq!(cache.len(), 10);
+    }
 }
 
 #[cfg(test)]

--- a/src/lfu/mod.rs
+++ b/src/lfu/mod.rs
@@ -268,6 +268,7 @@ impl<Key: Hash + Eq, Value> LfuCache<Key, Value> {
             // SAFETY: This is fine since self is uniquely borrowed.
             let key = unsafe { entry_ptr.as_ref().key.as_ref() };
             self.lookup.0.remove(key);
+            self.len -= 1;
 
             // SAFETY: entry_ptr is guaranteed to be a live reference and is
             // is separated from the data structure as a guarantee of pop_lfu.

--- a/src/lfu/mod.rs
+++ b/src/lfu/mod.rs
@@ -543,13 +543,30 @@ mod pop {
     }
 
     #[test]
-    fn set_capacity() {
+    fn set_capacity_evicts_multiple() {
         let mut cache = LfuCache::unbounded();
         for i in 0..100 {
             cache.insert(i, i + 100);
         }
         cache.set_capacity(10);
         assert_eq!(cache.len(), 10);
+    }
+
+    #[test]
+    fn pop_multiple_varying_frequencies() {
+        let mut cache = LfuCache::unbounded();
+        for i in 0..100 {
+            cache.insert(i, i + 100);
+        }
+        for i in 0..100 {
+            for _ in 0..i*i {
+                cache.get(&i).unwrap();
+            }
+        }
+        for i in 0..100 {
+            assert_eq!(100 - i, cache.len());
+            assert_eq!(Some(i + 100), cache.pop_lfu());
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes two issues which occur when removing multiple items via the `pop_lfu` interface and its derivatives.

1. When shrinking an unbounded `LfuCache` down to the capacity threshold when a new capacity is set, the least frequently used items are evicted. This leads, with the usage of `pop_lfu`, to the situation where the `len` member of `LfuCache` is not updated, leading to an endless loop in `set_capacity` as this member is used for identifying the cache size. A new test case `set_capacity_evicts_multiple` has been added for this.
2. When evicting multiple items of *varying frequencies* the head was not moved in the `pop_lfu` method. This can lead to the situation that subsequent `pop_lfu` calls - after a head node has been emptied by `pop_lfu` - falsely return `None` bc they assume the cache is empty. Instead they should move the head to the next node and start removing the remaining elements of the cache. The added test case `pop_multiple_varying_frequencies` demonstrates this case.

I hope these patches are helpful to you.

btw: Thanks alot for the effort you put into this crate, I used it in my thesis and it saved me a bunch of additional work :smile_cat: 