### PR TITLE
Add `peek_lfu_key` methods

### DIFF
--- a/src/lfu/freq_list.rs
+++ b/src/lfu/freq_list.rs
@@ -248,6 +248,14 @@ impl<Key: Hash + Eq, T> FrequencyList<Key, T> {
         self.head.and_then(|node| unsafe { node.as_ref() }.peek())
     }
 
+    /// Returns the key of the most recently added, lowest frequently accessed
+    /// item if it exists.
+    #[inline]
+    pub(super) fn peek_lfu_key(&self) -> Option<&Key> {
+        self.head
+            .and_then(|node| unsafe { node.as_ref() }.peek_key())
+    }
+
     /// Returns an iterator of all frequencies in the list.
     pub(super) fn frequencies(&self) -> impl Iterator<Item = usize> + FusedIterator + '_ {
         self.iter().map(|node| node.frequency)

--- a/src/lfu/mod.rs
+++ b/src/lfu/mod.rs
@@ -336,6 +336,14 @@ impl<Key: Hash + Eq, Value> LfuCache<Key, Value> {
         self.freq_list.peek_lfu()
     }
 
+    /// Peeks at the key for the next value to be evicted, if there is one. This
+    /// will not increment the access counter for that value.
+    #[inline]
+    #[must_use]
+    pub fn peek_lfu_key(&self) -> Option<&Key> {
+        self.freq_list.peek_lfu_key()
+    }
+
     /// Returns the current capacity of the cache.
     #[inline]
     #[must_use]

--- a/src/lfu/node.rs
+++ b/src/lfu/node.rs
@@ -135,6 +135,10 @@ impl<Key: Hash + Eq, T> Node<Key, T> {
         Some(&unsafe { self.elements?.as_ref() }.value)
     }
 
+    pub(super) fn peek_key(&self) -> Option<&Key> {
+        Some(&unsafe { self.elements?.as_ref() }.key)
+    }
+
     pub(super) fn len(&self) -> usize {
         let mut count = 0;
         let mut head = self.elements;
@@ -363,7 +367,9 @@ mod node {
 
     #[test]
     fn peek_empty() {
-        assert!(init_node().peek().is_none());
+        let node = init_node();
+        assert!(node.peek().is_none());
+        assert!(node.peek_key().is_none());
     }
 
     #[test]
@@ -372,6 +378,7 @@ mod node {
         let entry = Detached::new(Rc::new(1), 2);
         Node::push(NonNull::from(&mut *node), entry);
         assert_eq!(node.peek(), Some(&2));
+        assert_eq!(node.peek_key(), Some(&1));
     }
 
     #[test]

--- a/src/timed_lfu.rs
+++ b/src/timed_lfu.rs
@@ -198,6 +198,14 @@ impl<Key: Hash + Eq, Value> TimedLfuCache<Key, Value> {
         self.cache.peek_lfu()
     }
 
+    /// Peeks at the key for the next value to be evicted, if there is one. This
+    /// will not increment the access counter for that value.
+    #[inline]
+    #[must_use]
+    pub fn peek_lfu_key(&self) -> Option<&Key> {
+        self.cache.peek_lfu_key()
+    }
+
     /// Returns the current capacity of the cache.
     #[inline]
     #[must_use]


### PR DESCRIPTION
I noticed that there is no way to get the key that the evicted item (or the item about to be evicted) was/is stored under.

This PR adds a `peek_lfu_key` method for this particular need of mine.